### PR TITLE
add LWP::Protocol::https to enable Plagger::Agent to handle HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ RUN apt-get install -y libxml2-dev zlib1g-dev libexpat1-dev libdb-dev libssl-dev
 
 RUN cpanm YAML::Loader::Base
 RUN cpanm XML::Feed::RSS --notest
+RUN cpanm LWP::Protocol::https
 
 RUN cpanm Plagger


### PR DESCRIPTION
こんにちわ。はじめまして。

Plagger::Agent で HTTPS なサイトを扱う場合に LWP::Protocol::https が必要だったので追加する PR です。
一行だけの変更なので 私の方で fork したものを Docker Hub に登録することも考えましたが、似たような Dockerfile が複数散らばるのも紛らわしいと思うので取り込んでもらう方を選択しました。

よろしくお願いします〜
